### PR TITLE
added code of conduct from Public Lab Github link to the created file CODE_OF_CONDUCT.md

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,83 @@
+﻿Public Lab Code of Conduct
+Public Lab, PO Box 426113, Cambridge, MA 02142
+We are coming together with an intent to care for ourselves and one another. We want to nurture a compassionate democratic culture where responsibility is shared. We -- visitors, community members, community moderators, staff, organizers, sponsors, and all others -- hold ourselves accountable to the same values regardless of position or experience. For this to work for everybody, individual decisions will not be allowed to run counter to the welfare of other people. This community aspires to be a respectful place both during online and in-person interactions so that all people are able to fully participate with their dignity intact. This document is a piece of the culture we're creating.
+This code of conduct applies to all spaces managed by the Public Lab community and non-profit, both online and in person. It was written by the Conduct Committee (formed in 2015 during Public Lab’s annual conference “The Barnraising”) and facilitated by staff to provide a clear set of practical guidelines for multi-day events such as Barnraisings, events led by organizers and community members, and online venues such as the website, comment threads on software platforms, chatrooms, our mailing lists, the issue tracker, and any other forums created by Public Lab which the community uses for communication.
+We come from all kinds of backgrounds
+Our community is best when we fully invite and include participants from a wide range of backgrounds. We specifically design spaces to be welcoming and accessible to newcomers and folks from underrepresented groups. Public Lab is dedicated to providing a harassment-free, safe, and inclusive experience for everyone, regardless of personal and professional background, gender, gender identity and expression, style of clothing, sexual orientation, dis-/ability, physical appearance, body size, race, class, age, or religion. Public Lab resists and rejects: racism, sexism, ableism, ageism, homophobia, transphobia, body shaming, religion shaming, “geekier-than-thou” shaming, education bias, the shaming of people nursing children, and the dismissal or bullying of children or adults.
+We do not tolerate harassment or shaming
+While we operate under the assumption that all people involved with Public Lab subscribe to the basic understanding laid out above, we take these issues very seriously and think they should, in general, be taken seriously. Therefore, individuals who violate this Code both in and outside of Public Lab spaces may affect their ability to participate in Public Lab ranging from temporarily being placed into online moderation to, as a last resort, expulsion from the community. If you have any questions about our commitment to this framework and/or if you are unsure about aspects of it, email conduct@publiclab.org and we will do our best to provide clarification.
+How It Works
+Sometimes things go wrong. When a situation is uncomfortable, hurtful, exclusionary, or upsetting, there is a problem that should be addressed. This code of conduct is an effort to maintain a safe space for everyone, and to talk about what might happen if that space is compromised. Please see additional guidelines below for community behavior on how we expect people to interact with one another.
+Two helpful groups
+Conduct Committee (ConductCom): If at any time you experience something that you are not comfortable with, you may contact the Conduct Committee. As established during the 2015 Annual Barnraising, the following individuals are on the Conduct Committee: Klie Kliebert, Carla Green, Nick Shapiro, and Shannon Dosemagen, the executive director of the Public Lab nonprofit.
+If you would like to have a confidential conversation, connect with ConductCom in person or email via conduct@publiclab.org. A minimum of two committee members will confer and respond as swiftly as possible. If you would prefer to speak privately with a representative of the nonprofit, please contact the executive director directly either in person or by email: shannon@publiclab.org.
+To submit a report anonymously for review by ConductCom, go online via phone or computer to our anonymous “contact” app, located at http://bit.ly/PLReport. This contact app will be monitored daily at 8am CST during in-person events like Barnraisings and weekly at all other times. During multi-day in-person events hosted by the Public Lab non-profit, there will also be a physical suggestion box available. This box will be monitored throughout the event and can also be used to let us know if you need us to check on an anonymous online submission sooner.
+Moderators Group: The moderators group is responsible for addressing immediate moderation issues that arise during online violations of the code over email lists and Public Lab community websites, as well as approving first-time posts and generally handling spam. Instructions on how to become a moderator, and, if you’ve been placed in moderation how to begin the process of getting out of moderation can be found at: https://publiclab.org/wiki/moderation.
+
+A Culture of Empathy
+We begin interactions by acknowledging that we are part of a community with complementary goals. Different views are allowed to respectfully coexist in the same space. When something's happened and someone is uncomfortable, our first choice is to work through it. Endeavor to listen and appropriately adjust your behavior if someone approaches you privately with a request that you apologize or publicly requests that you stop an ongoing presentation. If someone questions your words, actions or motives, or "calls you out", hear their feedback and respond respectfully. It’s okay to not understand why something is hurtful or causes discomfort, as long as you approach it respectfully, with empathy. Repeating hurtful behavior after it has been addressed is disrespectful and is not allowed. Doing so will result in removal and subsequent banning from in-person events and being placed into moderation in online spaces.
+The first rule of engaging with others is consent
+During in-person gatherings, consent is important to highlight because the negotiation of consent can be subtle, and it’s easy to miss each other’s non-verbal cues, resulting in miscommunication and/or offense. During online interactions, consent can be even harder to distinguish.
+We make guesses or assessments of consent (willingness, welcome, invitation) all the time. Then we stay open to signs that the consent isn't there. Handshakes are a clear example of consent: someone offers a hand, and you take it if you want to shake it. A friendly smile might indicate consent to start a conversation. It might not. We learn that in the interaction. Sometimes we ask directly. We are open to making mistakes, and learning from them. The more we learn to be empathetic and see other people, the more we're able to talk about consent.
+Before you engage with someone on any level, be sure you have their consent. If your indications aren't being heard, you can also ask for help from other folks, especially Conduct Committee members and staff of the non-profit: "They aren't taking the hint. Will you help?" Turning a blind eye to hurtful interactions can be as bad for our community as the exchange itself. If you witness something, it's your responsibility to say something. This is how we keep each other accountable, encourage empathy, and keep our community safe. 
+Guidelines for in-person community behavior
+Do
+Don’t
+Respectfully share what method works best for you, while giving others space to think differently and contribute other ideas
+Disparage entire groups/sets of people for their beliefs or methods
+Ask permission to take pictures of and post about others on social media (see Media Consent, above)
+Upload photos, tag or mention others online without their consent
+Speak your own narrative, from your own unique culture
+Caricature the cultural expressions of groups you are not a member of
+Model inclusionary expertise - if others in the group appear to be “lost”, slow down; stop and ask for input
+Present information in a way / at a level that no one else in the room can understand, with no attempt to include others in the discussion
+Create events that are all-ages appropriate
+Use language that excludes youth and their experiences as vital contributors
+Give everyone a chance to talk, only interrupting if absolutely necessary - for example, Code of Conduct violations
+Repeatedly disrupt a discussion
+Stop, listen and ask for clarification if someone perceives your behavior or presentation as violating the Code of Conduct
+Ignore others’ request to stop potentially harmful behavior, even if it was an accident
+Cultivate a sense of humor based on other subjects, such as word play (especially puns!)
+Joke using words related to actual or insulting descriptions of people
+Use words that accurately describe the situation - For example, “The wind was ridiculously strong!” instead of “The wind was crazy!”
+Use disability and mental/emotional health terminology to describe a situation metaphorically, especially if the phrasing is meant as an insult
+Only discuss someone else’s lifestyle practices if they invite you to a conversation on the topic
+Make unwelcomed comments regarding a person’s lifestyle practices, including those related to food, health, parenting, relationships, and employment
+Ask someone before you hug them; keep your hands/body to yourself, even when joking, unless the other person has given verbal consent
+Initiate physical contact or simulate physical contact without consent
+Disengage and find another activity if someone did not invite you and is not engaging with you
+Violate personal space by continuing your physical presence into private spaces without consent
+Exercise the right to talk about your own identity if you want to, or not if you don’t want to
+Deliberately “out” any aspect of a person’s identity without their consent
+Use the pronouns people have specified for themselves
+Purposely misgender someone (ie, refusing to use their correct gender pronouns) after they have told you their correct pronouns
+Additional guidelines for online community behavior
+Online modes of interaction involve large numbers of people without the helpful presence of gestural, expression, and tonal cues regarding consent. Because of this, respectful and self-aware online conduct is both especially important and difficult. Our community has evolved specific guidelines for online interactions.
+If someone violates these guidelines, someone from the Moderators group will place them into moderation by changing that person’s posting permission on the relevant list, on the website, or both.
+Our triple notification standard for moderation means a point person from the Moderators group will:
+    1. e-mail the person directly with a brief explanation of what was violated,
+    2. send a summary email to the rest of the moderators group,
+    3. if it happened on a public list (vs a website), notify the list that one of our members has been placed into moderation with a brief explanation of what is not tolerated.
+If you wish to begin the process of getting out of moderation, respond to the email sent to you from moderators@publiclab.org. The Moderators group has the option to involve ConductCom.
+Do
+Don’t
+Stay on topic to make long threads easier to follow
+Send spurious one-line responses that effectively "spam" hundreds of people and lower the overall content quality of a conversation. (Exception: expressions of appreciation and encouragement!)
+Start a new thread to help others follow along. Important if your response starts to significantly diverge from the original topic
+Respond with off-topic information making it hard for the large group of readers to follow along
+Write short and literal subject lines to help the readers of the list manage the volume of communication
+Humor and euphemisms in subject lines are easily misunderstood, although enthusiasm is welcome!
+Mind your tone. We are not having this conversation in person, so it is all the more important to maintain a tone of respect
+Write in aggressive tone, disrespectful tone, mocking tone, off-color tone. Note: writing in all caps is regarded as shouting
+Media Consent
+    • ALWAYS check with parents about posting anything with minors.
+    • Never post the names of minors in conjunction with their photo.
+    • During multi-day events like Barnraisings most people will have signed media releases. Those who haven’t will be responsible for placing stickers on their nametags, and/or raising their hands in the moment to alert photographers to move them out of frame.
+    • For events where people have not signed blanket media release forms, the photographer is responsible for letting the room know that you are taking photos that will be posted online. Pay special attention to the presence of minors and their parent's wishes.
+Addendum for all staff
+Staff are bound by their Employment Handbook, you must reference it. Additionally:
+    • Direct problems that come up among community members to the Conduct Committee.
+    • When organizing events, circulate access information regarding wheelchair-accessible ADA bathrooms, non-gendered bathrooms, the presence of stairs or curb ramps in the parking lot, et cetera.
+    • During events that you are attending in person, solve accessibility issues by making sure attendees know where bathrooms are located and can access them by wheelchair without being obstructed by things like chairs, kites, contraptions, or cords.
+    • Watch for people feeling left out and include them.
+

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,4 +1,4 @@
-﻿This document was copied from its home at https://publiclab.org/conduct on October 12, 2017. See that page if you would like to submit your concerns in a safe, completely anonymous way, and to learn more about this document. 
+﻿This document was copied from its home at https://publiclab.org/conduct on February 10, 2019. See that page if you would like to submit your concerns in a safe, completely anonymous way, and to learn more about this document. 
 
 ****
 
@@ -49,7 +49,8 @@ During in-person gatherings, consent is important to highlight because the negot
 We make guesses or assessments of consent (willingness, welcome, invitation) all the time. Then we stay open to signs that the consent isn't there. Handshakes are a clear example of consent: someone offers a hand, and you take it if you want to shake it. A friendly smile might indicate consent to start a conversation. It might not. We learn that in the interaction. Sometimes we ask directly. We are open to making mistakes, and learning from them. The more we learn to be empathetic and see other people, the more we're able to talk about consent.
 
 Before you engage with someone on any level, be sure you have their consent. If your indications aren't being heard, you can also ask for help from other folks, especially Conduct Committee members and staff of the non-profit: "They aren't taking the hint. Will you help?" Turning a blind eye to hurtful interactions can be as bad for our community as the exchange itself. If you witness something, it's your responsibility to say something.  This is how we keep each other accountable, encourage empathy, and keep our community safe.
-
+
+
 ## Guidelines for in-person community behavior
 
 

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,83 +1,113 @@
-﻿Public Lab Code of Conduct
-Public Lab, PO Box 426113, Cambridge, MA 02142
+﻿This document was copied from its home at https://publiclab.org/conduct on October 12, 2017. See that page if you would like to submit your concerns in a safe, completely anonymous way, and to learn more about this document. 
+
+****
+
+# Public Lab Code of Conduct 
+
+_Public Lab, PO Box 426113, Cambridge, MA 02142_
+
 We are coming together with an intent to care for ourselves and one another. We want to nurture a compassionate democratic culture where responsibility is shared. We -- visitors, community members, community moderators, staff, organizers, sponsors, and all others -- hold ourselves accountable to the same values regardless of position or experience. For this to work for everybody, individual decisions will not be allowed to run counter to the welfare of other people. This community aspires to be a respectful place both during online and in-person interactions so that all people are able to fully participate with their dignity intact. This document is a piece of the culture we're creating.
-This code of conduct applies to all spaces managed by the Public Lab community and non-profit, both online and in person. It was written by the Conduct Committee (formed in 2015 during Public Lab’s annual conference “The Barnraising”) and facilitated by staff to provide a clear set of practical guidelines for multi-day events such as Barnraisings, events led by organizers and community members, and online venues such as the website, comment threads on software platforms, chatrooms, our mailing lists, the issue tracker, and any other forums created by Public Lab which the community uses for communication.
-We come from all kinds of backgrounds
+
+
+This code of conduct applies to all spaces managed by the Public Lab community and non-profit, both online and in person. It was written by the Conduct Committee (formed in 2015 during Public Lab’s annual conference “The Barnraising”) and facilitated by staff to provide a clear set of practical guidelines for multi-day events such as Barnraisings, events led by organizers and community members, and online venues such as the website, comment threads on software platforms, chatrooms, our mailing lists, the issue tracker, and any other forums created by Public Lab which the community uses for communication. 
+
+
+## We come from all kinds of backgrounds
+
 Our community is best when we fully invite and include participants from a wide range of backgrounds. We specifically design spaces to be welcoming and accessible to newcomers and folks from underrepresented groups. Public Lab is dedicated to providing a harassment-free, safe, and inclusive experience for everyone, regardless of personal and professional background, gender, gender identity and expression, style of clothing, sexual orientation, dis-/ability, physical appearance, body size, race, class, age, or religion. Public Lab resists and rejects: racism, sexism, ableism, ageism, homophobia, transphobia, body shaming, religion shaming, “geekier-than-thou” shaming, education bias, the shaming of people nursing children, and the dismissal or bullying of children or adults.
-We do not tolerate harassment or shaming
-While we operate under the assumption that all people involved with Public Lab subscribe to the basic understanding laid out above, we take these issues very seriously and think they should, in general, be taken seriously. Therefore, individuals who violate this Code both in and outside of Public Lab spaces may affect their ability to participate in Public Lab ranging from temporarily being placed into online moderation to, as a last resort, expulsion from the community. If you have any questions about our commitment to this framework and/or if you are unsure about aspects of it, email conduct@publiclab.org and we will do our best to provide clarification.
-How It Works
-Sometimes things go wrong. When a situation is uncomfortable, hurtful, exclusionary, or upsetting, there is a problem that should be addressed. This code of conduct is an effort to maintain a safe space for everyone, and to talk about what might happen if that space is compromised. Please see additional guidelines below for community behavior on how we expect people to interact with one another.
-Two helpful groups
-Conduct Committee (ConductCom): If at any time you experience something that you are not comfortable with, you may contact the Conduct Committee. As established during the 2015 Annual Barnraising, the following individuals are on the Conduct Committee: Klie Kliebert, Carla Green, Nick Shapiro, and Shannon Dosemagen, the executive director of the Public Lab nonprofit.
-If you would like to have a confidential conversation, connect with ConductCom in person or email via conduct@publiclab.org. A minimum of two committee members will confer and respond as swiftly as possible. If you would prefer to speak privately with a representative of the nonprofit, please contact the executive director directly either in person or by email: shannon@publiclab.org.
-To submit a report anonymously for review by ConductCom, go online via phone or computer to our anonymous “contact” app, located at http://bit.ly/PLReport. This contact app will be monitored daily at 8am CST during in-person events like Barnraisings and weekly at all other times. During multi-day in-person events hosted by the Public Lab non-profit, there will also be a physical suggestion box available. This box will be monitored throughout the event and can also be used to let us know if you need us to check on an anonymous online submission sooner.
-Moderators Group: The moderators group is responsible for addressing immediate moderation issues that arise during online violations of the code over email lists and Public Lab community websites, as well as approving first-time posts and generally handling spam. Instructions on how to become a moderator, and, if you’ve been placed in moderation how to begin the process of getting out of moderation can be found at: https://publiclab.org/wiki/moderation.
 
-A Culture of Empathy
-We begin interactions by acknowledging that we are part of a community with complementary goals. Different views are allowed to respectfully coexist in the same space. When something's happened and someone is uncomfortable, our first choice is to work through it. Endeavor to listen and appropriately adjust your behavior if someone approaches you privately with a request that you apologize or publicly requests that you stop an ongoing presentation. If someone questions your words, actions or motives, or "calls you out", hear their feedback and respond respectfully. It’s okay to not understand why something is hurtful or causes discomfort, as long as you approach it respectfully, with empathy. Repeating hurtful behavior after it has been addressed is disrespectful and is not allowed. Doing so will result in removal and subsequent banning from in-person events and being placed into moderation in online spaces.
-The first rule of engaging with others is consent
+## We do not tolerate harassment or shaming
+
+While we operate under the assumption that all people involved with Public Lab subscribe to the basic understanding laid out above, we take these issues very seriously and think they should, in general, be taken seriously. Therefore, individuals who violate this Code both in and outside of Public Lab spaces may affect their ability to participate in Public Lab ranging from temporarily being placed into online moderation to, as a last resort, expulsion from the community. If you have any questions about our commitment to this framework and/or if you are unsure about aspects of it, email conduct@publiclab.org and we will do our best to provide clarification.
+
+## How It Works
+
+Sometimes things go wrong. When a situation is uncomfortable, hurtful, exclusionary, or upsetting, there is a problem that should be addressed. This code of conduct is an effort to maintain a safe space for everyone, and to talk about what might happen if that space is compromised. Please see additional guidelines below for community behavior on how we expect people to interact with one another. 
+
+### Two helpful groups
+
+__Conduct Committee (ConductCom)__: If at any time you experience something that you are not comfortable with, you may contact the Conduct Committee. As established during the 2015 Annual Barnraising, the following individuals are on the Conduct Committee: Klie Kliebert, Carla Green, Nick Shapiro, and Shannon Dosemagen, the executive director of the Public Lab nonprofit. 
+
+
+If you would like to have a confidential conversation, connect with ConductCom in person or email via [conduct@publiclab.org](mailto:conduct@publiclab.org). A minimum of two committee members will confer and respond as swiftly as possible. If you would prefer to speak privately with a representative of the nonprofit, please contact the executive director directly either in person or by email: [shannon@publiclab.org.](mailto:conduct@publiclab.org)
+
+
+To submit a report anonymously for review by ConductCom, go online via phone or computer to our anonymous “contact” app, located at [http://bit.ly/PLReport](http://bit.ly/PLReport). This contact app will be monitored daily at 8am CST during in-person events like Barnraisings and weekly at all other times. During multi-day in-person events hosted by the Public Lab non-profit, there will also be a physical suggestion box available. This box will be monitored throughout the event and can also be used to let us know if you need us to check on an anonymous online submission sooner.
+
+
+__Moderators Group:__ The moderators group is responsible for addressing immediate moderation issues that arise during online violations of the code over email lists and Public Lab community websites, as well as approving first-time posts and generally handling spam. Instructions on how to become a moderator, and, if you’ve been placed in moderation how to begin the process of getting out of moderation can be found at: https://publiclab.org/wiki/moderation. 
+
+****
+
+## A Culture of Empathy
+
+We begin interactions by acknowledging that we are part of a community with complementary goals. Different views are allowed to respectfully coexist in the same space. When something's happened and someone is uncomfortable, our first choice is to work through it. Endeavor to listen and appropriately adjust your behavior if someone approaches you privately with a request that you apologize or publicly requests that you stop an ongoing presentation. If someone questions your words, actions or motives, or "calls you out", hear their feedback and respond respectfully. It’s okay to not understand why something is hurtful or causes discomfort, as long as you approach it respectfully, with empathy. Repeating hurtful behavior after it has been addressed is disrespectful and is not allowed. Doing so will result in removal and subsequent banning from in-person events and being placed into moderation in online spaces. 
+
+### The first rule of engaging with others is consent
 During in-person gatherings, consent is important to highlight because the negotiation of consent can be subtle, and it’s easy to miss each other’s non-verbal cues, resulting in miscommunication and/or offense. During online interactions, consent can be even harder to distinguish.
-We make guesses or assessments of consent (willingness, welcome, invitation) all the time. Then we stay open to signs that the consent isn't there. Handshakes are a clear example of consent: someone offers a hand, and you take it if you want to shake it. A friendly smile might indicate consent to start a conversation. It might not. We learn that in the interaction. Sometimes we ask directly. We are open to making mistakes, and learning from them. The more we learn to be empathetic and see other people, the more we're able to talk about consent.
-Before you engage with someone on any level, be sure you have their consent. If your indications aren't being heard, you can also ask for help from other folks, especially Conduct Committee members and staff of the non-profit: "They aren't taking the hint. Will you help?" Turning a blind eye to hurtful interactions can be as bad for our community as the exchange itself. If you witness something, it's your responsibility to say something. This is how we keep each other accountable, encourage empathy, and keep our community safe. 
-Guidelines for in-person community behavior
-Do
-Don’t
-Respectfully share what method works best for you, while giving others space to think differently and contribute other ideas
-Disparage entire groups/sets of people for their beliefs or methods
-Ask permission to take pictures of and post about others on social media (see Media Consent, above)
-Upload photos, tag or mention others online without their consent
-Speak your own narrative, from your own unique culture
-Caricature the cultural expressions of groups you are not a member of
-Model inclusionary expertise - if others in the group appear to be “lost”, slow down; stop and ask for input
-Present information in a way / at a level that no one else in the room can understand, with no attempt to include others in the discussion
-Create events that are all-ages appropriate
-Use language that excludes youth and their experiences as vital contributors
-Give everyone a chance to talk, only interrupting if absolutely necessary - for example, Code of Conduct violations
-Repeatedly disrupt a discussion
-Stop, listen and ask for clarification if someone perceives your behavior or presentation as violating the Code of Conduct
-Ignore others’ request to stop potentially harmful behavior, even if it was an accident
-Cultivate a sense of humor based on other subjects, such as word play (especially puns!)
-Joke using words related to actual or insulting descriptions of people
-Use words that accurately describe the situation - For example, “The wind was ridiculously strong!” instead of “The wind was crazy!”
-Use disability and mental/emotional health terminology to describe a situation metaphorically, especially if the phrasing is meant as an insult
-Only discuss someone else’s lifestyle practices if they invite you to a conversation on the topic
-Make unwelcomed comments regarding a person’s lifestyle practices, including those related to food, health, parenting, relationships, and employment
-Ask someone before you hug them; keep your hands/body to yourself, even when joking, unless the other person has given verbal consent
-Initiate physical contact or simulate physical contact without consent
-Disengage and find another activity if someone did not invite you and is not engaging with you
-Violate personal space by continuing your physical presence into private spaces without consent
-Exercise the right to talk about your own identity if you want to, or not if you don’t want to
-Deliberately “out” any aspect of a person’s identity without their consent
-Use the pronouns people have specified for themselves
-Purposely misgender someone (ie, refusing to use their correct gender pronouns) after they have told you their correct pronouns
-Additional guidelines for online community behavior
-Online modes of interaction involve large numbers of people without the helpful presence of gestural, expression, and tonal cues regarding consent. Because of this, respectful and self-aware online conduct is both especially important and difficult. Our community has evolved specific guidelines for online interactions.
-If someone violates these guidelines, someone from the Moderators group will place them into moderation by changing that person’s posting permission on the relevant list, on the website, or both.
-Our triple notification standard for moderation means a point person from the Moderators group will:
-    1. e-mail the person directly with a brief explanation of what was violated,
-    2. send a summary email to the rest of the moderators group,
-    3. if it happened on a public list (vs a website), notify the list that one of our members has been placed into moderation with a brief explanation of what is not tolerated.
-If you wish to begin the process of getting out of moderation, respond to the email sent to you from moderators@publiclab.org. The Moderators group has the option to involve ConductCom.
-Do
-Don’t
-Stay on topic to make long threads easier to follow
-Send spurious one-line responses that effectively "spam" hundreds of people and lower the overall content quality of a conversation. (Exception: expressions of appreciation and encouragement!)
-Start a new thread to help others follow along. Important if your response starts to significantly diverge from the original topic
-Respond with off-topic information making it hard for the large group of readers to follow along
-Write short and literal subject lines to help the readers of the list manage the volume of communication
-Humor and euphemisms in subject lines are easily misunderstood, although enthusiasm is welcome!
-Mind your tone. We are not having this conversation in person, so it is all the more important to maintain a tone of respect
-Write in aggressive tone, disrespectful tone, mocking tone, off-color tone. Note: writing in all caps is regarded as shouting
-Media Consent
-    • ALWAYS check with parents about posting anything with minors.
-    • Never post the names of minors in conjunction with their photo.
-    • During multi-day events like Barnraisings most people will have signed media releases. Those who haven’t will be responsible for placing stickers on their nametags, and/or raising their hands in the moment to alert photographers to move them out of frame.
-    • For events where people have not signed blanket media release forms, the photographer is responsible for letting the room know that you are taking photos that will be posted online. Pay special attention to the presence of minors and their parent's wishes.
-Addendum for all staff
-Staff are bound by their Employment Handbook, you must reference it. Additionally:
-    • Direct problems that come up among community members to the Conduct Committee.
-    • When organizing events, circulate access information regarding wheelchair-accessible ADA bathrooms, non-gendered bathrooms, the presence of stairs or curb ramps in the parking lot, et cetera.
-    • During events that you are attending in person, solve accessibility issues by making sure attendees know where bathrooms are located and can access them by wheelchair without being obstructed by things like chairs, kites, contraptions, or cords.
-    • Watch for people feeling left out and include them.
 
+We make guesses or assessments of consent (willingness, welcome, invitation) all the time. Then we stay open to signs that the consent isn't there. Handshakes are a clear example of consent: someone offers a hand, and you take it if you want to shake it. A friendly smile might indicate consent to start a conversation. It might not. We learn that in the interaction. Sometimes we ask directly. We are open to making mistakes, and learning from them. The more we learn to be empathetic and see other people, the more we're able to talk about consent.
+
+Before you engage with someone on any level, be sure you have their consent. If your indications aren't being heard, you can also ask for help from other folks, especially Conduct Committee members and staff of the non-profit: "They aren't taking the hint. Will you help?" Turning a blind eye to hurtful interactions can be as bad for our community as the exchange itself. If you witness something, it's your responsibility to say something.  This is how we keep each other accountable, encourage empathy, and keep our community safe.
+
+## Guidelines for in-person community behavior
+
+
+Do | Don’t
+----------- | -----------
+Respectfully share what method works best for you, while giving others space to think differently and contribute other ideas | Disparage entire groups/sets of people for their beliefs or methods
+Ask permission to take pictures of and post about others on social media (see Media Consent, above)| Upload photos, tag or mention others online without their consent 
+Speak your own narrative, from your own unique culture | Caricature the cultural expressions of groups you are not a member of
+Model inclusionary expertise - if others in the group appear to be “lost”, slow down; stop and ask for input | Present information in a way / at a level that no one else in the room can understand, with no attempt to include others in the discussion
+Create events that are all-ages appropriate | Use language that excludes youth and their experiences as vital contributors
+Give everyone a chance to talk, only interrupting if absolutely necessary - for example, Code of Conduct violations | Repeatedly disrupt a discussion
+Stop, listen and ask for clarification if someone perceives your behavior or presentation as violating the Code of Conduct | Ignore others’ request to stop potentially harmful behavior, even if it was an accident
+Cultivate a sense of humor based on other subjects, such as word play (especially puns!)  | Joke using words related to actual or insulting descriptions of people
+Use words that accurately describe the situation - For example, “The wind was ridiculously strong!” instead of “The wind was crazy!” | Use disability and mental/emotional health terminology to describe a situation metaphorically, especially if the phrasing is meant as an insult
+Only discuss someone else’s lifestyle practices if they invite you to a conversation on the topic | Make unwelcomed comments regarding a person’s lifestyle practices, including those related to food, health, parenting, relationships, and employment
+Ask someone before you hug them; keep your hands/body to yourself, even when joking, unless the other person has given verbal consent | Initiate physical contact or simulate physical contact without consent 
+Disengage and find another activity if someone did not invite you and is not engaging with you | Violate personal space by continuing your physical presence into private spaces without consent
+Exercise the right to talk about your own identity if you want to, or not if you don’t want to | Deliberately “out” any aspect of a person’s identity without their consent
+Use the pronouns people have specified for themselves | Purposely misgender someone (ie, refusing to use their correct gender pronouns) after they have told you their correct pronouns 
+
+
+## Additional guidelines for online community behavior
+
+
+Online modes of interaction involve large numbers of people without the helpful presence of gestural, expression, and tonal cues regarding consent. Because of this, respectful and self-aware online conduct is both especially important and difficult. Our community has evolved specific guidelines for online interactions. 
+
+_If someone violates these guidelines, someone from the Moderators group will place them into moderation by changing that person’s posting permission on the relevant list, on the website, or both._
+
+Our triple notification standard for moderation means a point person from the Moderators group will:
+
+1. e-mail the person directly with a brief explanation of what was violated,
+2. send a summary email to the rest of the moderators group, 
+3. if it happened on a public list (vs a website), notify the list that one of our members has been placed into moderation with a brief explanation of what is not tolerated.
+
+
+If you wish to begin the process of getting out of moderation, respond to the email sent to you from [moderators@publiclab.org](mailto:moderators@publiclab.org). The Moderators group has the option to involve ConductCom.
+
+
+Do | Don’t
+-------|--------
+Stay on topic to make long threads easier to follow |Send spurious one-line responses that effectively "spam" hundreds of people and lower the overall content quality of a conversation. (Exception: expressions of appreciation and encouragement!)
+Start a new thread to help others follow along. Important if your response starts to significantly diverge from the original topic | Respond with off-topic information making it hard for the large group of readers to follow along
+Write short and literal subject lines to help the readers of the list manage the volume of communication | Humor and euphemisms in subject lines are easily misunderstood, although enthusiasm is welcome! 
+Mind your tone. We are not having this conversation in person, so it is all the more important to maintain a tone of respect | Write in aggressive tone, disrespectful tone, mocking tone, off-color tone. Note: writing in all caps is regarded as shouting
+
+## Media Consent
+
+* ALWAYS check with parents about posting anything with minors.
+* Never post the names of minors in conjunction with their photo. 
+* During multi-day events like Barnraisings most people will have signed media releases. Those who haven’t will be responsible for placing stickers on their nametags, and/or raising their hands in the moment to alert photographers to move them out of frame. 
+* For events where people have not signed blanket media release forms, the photographer is responsible for letting the room know that you are taking photos that will be posted online. Pay special attention to the presence of minors and their parent's wishes.
+
+
+## Addendum for all staff 
+
+Staff are bound by their Employment Handbook, you must reference it. Additionally:  
+
+* Direct problems that come up among community members to the Conduct Committee.
+* When organizing events, circulate access information regarding wheelchair-accessible ADA bathrooms, non-gendered bathrooms, the presence of stairs or curb ramps in the parking lot, et cetera.
+* During events that you are attending in person, solve accessibility issues by making sure attendees know where bathrooms are located and can access them by wheelchair without being obstructed by things like chairs, kites, contraptions, or cords. 
+* Watch for people feeling left out and include them.  


### PR DESCRIPTION
…_CONDUCT.md ... Unfortunately I could only safe the file in a txt format, and so it is not possible to display the Dos and Donts in the table (as rendered on the Public Lab Github link on the issue page).

If there are any issues with this pull request, please do let me know and I will make the appropriate edits. 

Thanks,
Riz :)