### PR TITLE
Fixed (#179) Toggle overlay controls on only when using grid overlay

### DIFF
--- a/index.html
+++ b/index.html
@@ -154,7 +154,7 @@
                   <i class="fa fa-th" aria-hidden="true"></i>
                 </button>
               </div>
-              <div class="col-md-8">
+              <div class="col-md-8" id="overlay-controls-container">
                 <input id="overlay-slider" type="range" min="10" max="50" value="100"/>
                 <span id="overlay-size" style="color:#ccc;"></span>
                 <button id="overlay-save-btn" class="btn btn-primary">Save</button>

--- a/src/ui/interface.js
+++ b/src/ui/interface.js
@@ -104,6 +104,7 @@ module.exports = function Interface(options) {
 
     $("#overlay-btn").click(function() {
       $("#overlay-container").toggle();
+      $("#overlay-controls-container").toggle();
       $("#overlay-btn").toggleClass("btn-success");
     });
 


### PR DESCRIPTION
[Fixed Toggle overlay controls on only when using grid overlay (#179)](https://github.com/publiclab/infragram/issues/179)

   $("#overlay-container").toggle();
+      $("#overlay-controls-container").toggle();
       $("#overlay-btn").toggleClass("btn-success");
     });

and added id as.

<div class="col-md-8" id="overlay-controls-container"> 

Please check it out my Pull request @TildaDares 