### PR TITLE
Fixes #194 Modal broken Links

### DIFF
--- a/dist/infragram.css
+++ b/dist/infragram.css
@@ -77,11 +77,6 @@ div#colorbar-container canvas#colorbar {
     height:auto;
   }
 }
-
-.container {
-  padding-left:unset;
-}
-
 #overlay-container {
   position:absolute;
  display: inline-block;

--- a/index.html
+++ b/index.html
@@ -38,7 +38,17 @@
              <!--<div class="modal-header"></div>-->
              <div class="modal-body">
                <h3>Quick start</h3>
-               <p>Choose from these presets to get up and running quickly. These auto-load common 2. Analysis and 3. Colorize settings so you don't have to manually choose them.</p>
+               <p>Choose from these presets to get up and running quickly:
+                 <p>
+                 1. These auto-load common
+                 </p> 
+                 <p>
+                  2. Analysis and
+                 </p>
+                 <p>
+                  3. Colorize settings so you don't have to manually choose them.</p>
+                 </p>
+                  
                  <table class="table">
                    <tr>
                      <td width="30%"><b>Raw</b></td>
@@ -47,13 +57,13 @@
                    </tr>
                    <tr>
                      <td><b>NDVI for <span style="color:blue;">BLUE</span> filters</b></td>
-                     <td>basic plant analysis for <a href="http://store.publiclab.org/product/infragram-diy-filter-pack">Infragram filter packs</a> and <a href="http://store.publiclab.org/product/infragram-webcam">webcams</a></td>
+                     <td>Basic plant analysis for <a href="https://store.publiclab.org/collections/featured-kits/products/infragram-pi-camera?variant=14249592029293">Infragram Pi Camera</a></td>
                      <td><a class="btn btn-primary" id="preset_ndvi_blue">Basic</a>
                          <a class="btn btn-success" id="preset_ndvi_blue_color">Colorized</a></td>
                    </tr>
                    <tr>
                      <td><b>NDVI for <span style="color:red;">RED</span> filters</b></td>
-                     <td>basic plant analysis for <a href="http://store.publiclab.org/products/infragram-point-shoot-plant-cam">Infragram Point &amp; Shoot cameras</a></td>
+                     <td>Basic plant analysis for <a href="https://store.publiclab.org/collections/featured-kits/products/infragram-diy-filter-pack?_pos=1&_sid=ff960859b&_ss=r&variant=1058088684">Infragram DIY Filter Pack</a></td>
                      <td><a class="btn btn-primary" id="preset_ndvi_red">Basic</a>
                          <a class="btn btn-success" id="preset_ndvi_red_color">Colorized</a></td>
                    </tr>
@@ -62,7 +72,7 @@
 
 	    </div>
             <div class="modal-footer">
-              <a data-dismiss="modal" data-toggle="modal" class="btn">cancel</a>
+              <a data-dismiss="modal" data-toggle="modal" class="btn">Cancel</a>
             </div>
           </div>
         </div>


### PR DESCRIPTION
Modal Links which are broken are fixed #194 .

Solution:

Products which are available in the Public lab store are replaced with broken links

<img width="1440" alt="Screenshot 2022-03-03 at 12 15 51 PM" src="https://user-images.githubusercontent.com/82027712/156511371-7087bbeb-439a-40d8-a07b-fea87184dd90.png">
.