### PR TITLE
Fixes Modal Links which  are broken. #194

### DIFF
--- a/index.html
+++ b/index.html
@@ -47,22 +47,22 @@
                    </tr>
                    <tr>
                      <td><b>NDVI for <span style="color:blue;">BLUE</span> filters</b></td>
-                     <td>basic plant analysis for <a href="http://store.publiclab.org/product/infragram-diy-filter-pack">Infragram filter packs</a> and <a href="http://store.publiclab.org/product/infragram-webcam">webcams</a></td>
+                     <td>Basic plant analysis for <a target="_blank" href="https://store.publiclab.org/collections/diy-infrared-photography/products/infragram-pi-camera">Infragram Pi Camera</a> and <a target="_blank"  href="https://store.publiclab.org/collections/diy-infrared-photography/products/raspberry-pi-camera">Raspberry Pi Camera</a></td>
                      <td><a class="btn btn-primary" id="preset_ndvi_blue">Basic</a>
                          <a class="btn btn-success" id="preset_ndvi_blue_color">Colorized</a></td>
                    </tr>
                    <tr>
                      <td><b>NDVI for <span style="color:red;">RED</span> filters</b></td>
-                     <td>basic plant analysis for <a href="http://store.publiclab.org/products/infragram-point-shoot-plant-cam">Infragram Point &amp; Shoot cameras</a></td>
+                     <td>Basic plant analysis for <a target="_blank"  href="https://store.publiclab.org/collections/all-products/products/infragram-diy-filter-pack">Infragram DIY Filter Pack</a></td>
                      <td><a class="btn btn-primary" id="preset_ndvi_red">Basic</a>
                          <a class="btn btn-success" id="preset_ndvi_red_color">Colorized</a></td>
                    </tr>
                  </table>
-                 <p>Post a research note at <a href="http://publiclab.org">PublicLab.org</a> and email <a href="mailto:plots-dev@googlegroups.com">plots-dev@googlegroups.com</a> to suggest new presets.</p>
+                 <p>Post a research note at <a target="_blank"  href="http://publiclab.org">PublicLab.org</a> and email <a href="mailto:plots-dev@googlegroups.com">plots-dev@googlegroups.com</a> to suggest new presets.</p>
 
 	    </div>
             <div class="modal-footer">
-              <a data-dismiss="modal" data-toggle="modal" class="btn">cancel</a>
+              <a data-dismiss="modal" data-toggle="modal" class="btn">Cancel</a>
             </div>
           </div>
         </div>


### PR DESCRIPTION
Fixes Modal Links which  are broken ( #194)


Added target='_blank' which takes to the next tab.

Solution:

Products which are available in the Public lab store are replaced with broken links.

![image](https://user-images.githubusercontent.com/82027712/156569471-8f9cbff5-8050-4724-b9bb-de4af0b0cbff.png)
