### PR TITLE
Removed unused style attr in pi/index.html 

### DIFF
--- a/pi/index.html
+++ b/pi/index.html
@@ -1,7 +1,8 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
-    
+   
+    <!-- http-server to run code  -->
     <title>Infragram | by Public Lab - Home</title>
 
     <meta http-equiv="content-type" content="text/html;charset=utf-8">
@@ -128,7 +129,7 @@
             </div>
           </div>
 
-          <div class="zone last" id="save-zone" style="">
+          <div class="zone last" id="save-zone">
             <p>OUTPUT</p>
             <button onClick="infragram.download();openInSequencer();" class="btn btn-primary btn-lg">Download</button>
             <button onClick="openInSequencer();" class="btn btn-primary btn-lg">Sequencer</button>

--- a/pi/index.html
+++ b/pi/index.html
@@ -1,8 +1,6 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
-   
-    <!-- http-server to run code  -->
     <title>Infragram | by Public Lab - Home</title>
 
     <meta http-equiv="content-type" content="text/html;charset=utf-8">


### PR DESCRIPTION
 The Pi/index.html threw an error after I cloned it, I checked and saw that the style attribute on line 132 was empty, however when I inspected and checked the console the styling for this element is from infragram.css. I removed the style attribute in pi/index.html and the code worked fine without any error.