### PR TITLE
Grid overlay button style changed from primary to default

### DIFF
--- a/index.html
+++ b/index.html
@@ -144,7 +144,7 @@
             <p>4. OVERLAY</p>
             <div class="row">
               <div class="col-md-4">
-                <button id="overlay-btn" class="btn btn-lg btn-primary">
+                <button id="overlay-btn" class="btn btn-lg btn-default">
                   <i class="fa fa-th" aria-hidden="true"></i>
                 </button>
               </div>


### PR DESCRIPTION
I have successfully changed the grid overlay button style from primary to default.