### PR TITLE
hide grid overlay controls on initial display 

### DIFF
--- a/index.html
+++ b/index.html
@@ -148,7 +148,8 @@
                   <i class="fa fa-th" aria-hidden="true"></i>
                 </button>
               </div>
-              <div class="col-md-8" id="overlay-controls-container">
+              
+	      <div class="col-md-8" id="overlay-controls-container" style="display:none;">
                 <input id="overlay-slider" type="range" min="10" max="50" value="100"/>
                 <span id="overlay-size" style="color:#ccc;"></span>
                 <button id="overlay-save-btn" class="btn btn-primary">Save</button>


### PR DESCRIPTION
Fixes #306 added a code that hides grid overlay controls on initial display  